### PR TITLE
Enable new models, fix internet chat, fix youtube transcription, bugfixes and other small changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ These commands are grouped, so each group has a prefix but you can easily tab co
 - `nodes` defines how many nodes inside the built index after webpage retrieval to use. 
 - Increasing the scope or the nodes will make the requests take longer and will be more expensive, but will usually be more accurate.
   
-`/internet chat search_scope:<number> use_gpt:<True/False>` - Start an internet-connected chat with GPT, connected to Google and Wolfram.
+`/internet chat search_scope:<number> model:<turbo or gpt4>` - Start an internet-connected chat with GPT, connected to Google and Wolfram.
 
 ### Custom Indexes Commands  
   

--- a/cogs/commands.py
+++ b/cogs/commands.py
@@ -1130,20 +1130,20 @@ class Commands(discord.Cog, name="Commands"):
         default=2,
     )
     @discord.option(
-        name="use_gpt4",
-        description="Use GPT4 instead of GPT3",
+        name="model",
+        description="The model to use for the request (querying, not composition)",
         required=False,
-        input_type=discord.SlashCommandOptionType.boolean,
-        default=False,
+        default="gpt-3.5-turbo",
+        autocomplete=Settings_autocompleter.get_index_and_search_models,
     )
     async def chat(
         self,
         ctx: discord.ApplicationContext,
+        model: str,
         search_scope: int = 2,
-        use_gpt4: bool = False,
     ):
         await self.search_cog.search_chat_command(
-            ctx, search_scope=search_scope, use_gpt4=use_gpt4
+            ctx, search_scope=search_scope, model=model
         )
 
     # Search slash commands

--- a/cogs/search_service_cog.py
+++ b/cogs/search_service_cog.py
@@ -199,7 +199,7 @@ class CustomTextRequestWrapper(BaseModel):
         print("The scraped text content is: " + text)
         if len(text) < 5:
             return "This website could not be scraped. I cannot answer this question."
-        if (not model in Models.CHATGPT_MODELS and tokens > 3000) or (
+        if (model in Models.CHATGPT_MODELS and tokens > 3000) or (
             model in Models.GPT4_MODELS and tokens > 7000
         ):
             with tempfile.NamedTemporaryFile(mode="w", delete=False) as f:
@@ -211,7 +211,7 @@ class CustomTextRequestWrapper(BaseModel):
                 index = GPTVectorStoreIndex.from_documents(
                     document, service_context=service_context, use_async=True
                 )
-                response_text = index.query(
+                response_text = index.as_query_engine.query(
                     original_query,
                     refine_template=CHAT_REFINE_PROMPT,
                     similarity_top_k=4,

--- a/cogs/search_service_cog.py
+++ b/cogs/search_service_cog.py
@@ -48,7 +48,6 @@ from llama_index.retrievers import VectorIndexRetriever
 from llama_index.query_engine import RetrieverQueryEngine
 from llama_index.prompts.chat_prompts import CHAT_REFINE_PROMPT
 from pydantic import Extra, BaseModel
-from transformers import GPT2TokenizerFast
 import tiktoken
 
 from models.embed_statics_model import EmbedStatics

--- a/cogs/search_service_cog.py
+++ b/cogs/search_service_cog.py
@@ -42,10 +42,14 @@ from llama_index import (
     SimpleDirectoryReader,
     ServiceContext,
     OpenAIEmbedding,
+    ResponseSynthesizer
 )
+from llama_index.retrievers import VectorIndexRetriever
+from llama_index.query_engine import RetrieverQueryEngine
 from llama_index.prompts.chat_prompts import CHAT_REFINE_PROMPT
 from pydantic import Extra, BaseModel
 from transformers import GPT2TokenizerFast
+import tiktoken
 
 from models.embed_statics_model import EmbedStatics
 from models.search_model import Search
@@ -153,7 +157,6 @@ class CustomTextRequestWrapper(BaseModel):
 
     headers: Optional[Dict[str, str]] = None
     aiosession: Optional[aiohttp.ClientSession] = None
-    tokenizer = GPT2TokenizerFast.from_pretrained("gpt2")
 
     class Config:
         """Configuration for this pydantic object."""
@@ -172,12 +175,14 @@ class CustomTextRequestWrapper(BaseModel):
         # the "url" field is actuall some input from the LLM, it is a comma separated string of the url and a boolean value and the original query
         try:
             url, model, original_query = url.split(",")
+            url = url.strip()
+            model = model.strip()
+            original_query = original_query.strip()
         except:
             url = url
             model = "gpt-3.5-turbo"
-            original_query = "No Original Query Provided"
+            original_query = "No Original Query Provided" 
 
-        model = model == "gpt-3.5-turbo"
         """GET the URL and return the text."""
         text = self.requests.get(url, **kwargs).text
 
@@ -192,15 +197,15 @@ class CustomTextRequestWrapper(BaseModel):
         text = soup.get_text()
 
         # Clean up white spaces
-        text = re.sub(r"\s+", " ", text)
+        text = re.sub(r"\s+", " ", text).strip()
 
         # If not using GPT-4 and the text token amount is over 3500, truncate it to 3500 tokens
-        tokens = len(self.tokenizer(text)["input_ids"])
-        print("The scraped text content is: " + text)
+        enc = tiktoken.encoding_for_model(model)
+        tokens = len(enc.encode(text))
         if len(text) < 5:
             return "This website could not be scraped. I cannot answer this question."
-        if (model in Models.CHATGPT_MODELS and tokens > 3000) or (
-            model in Models.GPT4_MODELS and tokens > 7000
+        if (model in Models.CHATGPT_MODELS and tokens > Models.get_max_tokens(model) - 1000) or (
+            model in Models.GPT4_MODELS and tokens > Models.get_max_tokens(model) - 1000
         ):
             with tempfile.NamedTemporaryFile(mode="w", delete=False) as f:
                 f.write(text)
@@ -211,12 +216,19 @@ class CustomTextRequestWrapper(BaseModel):
                 index = GPTVectorStoreIndex.from_documents(
                     document, service_context=service_context, use_async=True
                 )
-                response_text = index.as_query_engine.query(
-                    original_query,
-                    refine_template=CHAT_REFINE_PROMPT,
-                    similarity_top_k=4,
-                    response_mode="compact",
+                retriever = VectorIndexRetriever(
+                    index = index, similarity_top_k=4, service_context=service_context
                 )
+                response_synthesizer = ResponseSynthesizer.from_args(
+                    response_mode="compact",
+                    refine_template=CHAT_REFINE_PROMPT,
+                    service_context=service_context,
+                    use_async=True
+                )
+                query_engine = RetrieverQueryEngine(
+                    retriever=retriever, response_synthesizer=response_synthesizer
+                )
+                response_text = query_engine.query(original_query)
                 return response_text
 
         return text
@@ -458,7 +470,7 @@ class SearchService(discord.Cog, name="SearchService"):
             Tool(
                 name="Web-Crawling-Tool",
                 func=requests.get,
-                description=f"Useful for when the user provides you with a website link, use this tool to crawl the website and retrieve information from it. The input to this tool is a comma separated list of three values, the first value is the link to crawl for, and the second value is the value of 'model', which is {model}, and the third value is the original question that the user asked. For example, an input could be 'https://google.com', False, 'What is this webpage?'. This tool should only be used if a direct link is provided and not in conjunction with other tools.",
+                description=f"Useful for when the user provides you with a website link, use this tool to crawl the website and retrieve information from it. The input to this tool is a comma separated list of three values, the first value is the link to crawl for, and the second value is {model} and is the GPT model used, and the third value is the original question that the user asked. For example, an input could be 'https://google.com', gpt-3.5-turbo, 'What is this webpage?'. This tool should only be used if a direct link is provided and not in conjunction with other tools.",
             ),
         ]
 

--- a/cogs/search_service_cog.py
+++ b/cogs/search_service_cog.py
@@ -199,7 +199,9 @@ class CustomTextRequestWrapper(BaseModel):
         print("The scraped text content is: " + text)
         if len(text) < 5:
             return "This website could not be scraped. I cannot answer this question."
-        if (not model in Models.CHATGPT_MODELS and tokens > 3000) or (model in Models.GPT4_MODELS and tokens > 7000):
+        if (not model in Models.CHATGPT_MODELS and tokens > 3000) or (
+            model in Models.GPT4_MODELS and tokens > 7000
+        ):
             with tempfile.NamedTemporaryFile(mode="w", delete=False) as f:
                 f.write(text)
                 f.close()
@@ -479,9 +481,7 @@ class SearchService(discord.Cog, name="SearchService"):
             memory_key="chat_history", return_messages=True
         )
 
-        llm = ChatOpenAI(
-            model=model, temperature=0, openai_api_key=OPENAI_API_KEY
-        )
+        llm = ChatOpenAI(model=model, temperature=0, openai_api_key=OPENAI_API_KEY)
 
         agent_chain = initialize_agent(
             tools,

--- a/cogs/transcription_service_cog.py
+++ b/cogs/transcription_service_cog.py
@@ -52,16 +52,20 @@ class TranscribeService(discord.Cog, name="TranscribeService"):
 
         if await UrlCheck.check_youtube_link(link):
             # We need to download the youtube video and save it to a temporary file
-            
+
             options = {
-                'format': 'bestaudio/best',
-                'outtmpl': os.path.join("audiotemp/", f'{ctx.user.id}temp.%(ext)s'),  # save file as the videos title
-                'quiet': True,
-                'postprocessors': [{
-                    'key': 'FFmpegExtractAudio',
-                    'preferredcodec': 'mp3',
-                    'preferredquality': '192',
-                }],
+                "format": "bestaudio/best",
+                "outtmpl": os.path.join(
+                    "audiotemp/", f"{ctx.user.id}temp.%(ext)s"
+                ),  # save file as the videos title
+                "quiet": True,
+                "postprocessors": [
+                    {
+                        "key": "FFmpegExtractAudio",
+                        "preferredcodec": "mp3",
+                        "preferredquality": "192",
+                    }
+                ],
             }
 
             # Delete audiotemp/{str(ctx.user.id)}temp.mp3 if it already exists
@@ -71,6 +75,7 @@ class TranscribeService(discord.Cog, name="TranscribeService"):
             def download_video(url, options):
                 with YoutubeDL(options) as ydl:
                     ydl.download([url])
+
             try:
                 await asyncio.get_running_loop().run_in_executor(
                     None,

--- a/cogs/transcription_service_cog.py
+++ b/cogs/transcription_service_cog.py
@@ -1,15 +1,17 @@
 import asyncio
 import traceback
+import os
 from functools import partial
 from pathlib import Path
+from yt_dlp import YoutubeDL
 
-import aiohttp
+
 import discord
 from discord.ext import pages
-from pytube import YouTube
 
 from models.deepl_model import TranslationModel
 from models.embed_statics_model import EmbedStatics
+from models.check_model import UrlCheck
 from services.environment_service import EnvService
 from services.text_service import TextService
 
@@ -48,20 +50,34 @@ class TranscribeService(discord.Cog, name="TranscribeService"):
             if not user_api_key:
                 return
 
-        if "youtube" in link:
+        if await UrlCheck.check_youtube_link(link):
             # We need to download the youtube video and save it to a temporary file
-            yt = YouTube(link)
+            
+            options = {
+                'format': 'bestaudio/best',
+                'outtmpl': os.path.join("audiotemp/", f'{ctx.user.id}temp.%(ext)s'),  # save file as the videos title
+                'quiet': True,
+                'postprocessors': [{
+                    'key': 'FFmpegExtractAudio',
+                    'preferredcodec': 'mp3',
+                    'preferredquality': '192',
+                }],
+            }
 
             # Delete audiotemp/{str(ctx.user.id)}temp.mp3 if it already exists
             if Path("audiotemp/{}temp.mp3".format(str(ctx.user.id))).exists():
                 Path("audiotemp/{}temp.mp3".format(str(ctx.user.id))).unlink()
+
+            def download_video(url, options):
+                with YoutubeDL(options) as ydl:
+                    ydl.download([url])
             try:
-                file_path = await asyncio.get_running_loop().run_in_executor(
+                await asyncio.get_running_loop().run_in_executor(
                     None,
                     partial(
-                        yt.streams.filter().first().download,
-                        output_path="audiotemp",
-                        filename="{}temp".format(str(ctx.user.id)),
+                        download_video,
+                        link,
+                        options,
                     ),
                 )
             except Exception as e:
@@ -79,6 +95,7 @@ class TranscribeService(discord.Cog, name="TranscribeService"):
             return
 
         # Load the file object from the file_path
+        file_path = Path("audiotemp/{}temp.mp3".format(str(ctx.user.id)))
         file = discord.File(file_path)
 
         response_message = await ctx.respond(

--- a/models/autocomplete_model.py
+++ b/models/autocomplete_model.py
@@ -99,7 +99,8 @@ class Settings_autocompleter:
     async def get_index_and_search_models(
         ctx: discord.AutocompleteContext,
     ):
-        return ["gpt-3.5-turbo", "gpt-4"]
+        models = Models.CHATGPT_MODELS + Models.GPT4_MODELS
+        return [value for value in models if value.startswith(ctx.value.lower())]
 
     async def get_converse_models(
         ctx: discord.AutocompleteContext,

--- a/models/check_model.py
+++ b/models/check_model.py
@@ -1,4 +1,6 @@
 import discord
+import re
+import aiohttp
 
 from services.environment_service import EnvService
 from typing import Callable
@@ -117,3 +119,17 @@ class Check:
             return True
 
         return inner
+
+class UrlCheck:
+    @staticmethod
+    async def check_youtube_link(url):
+        youtube_regex = r'(https?://)?(www\.)?(youtube|youtu|youtube-nocookie)\.(com|be)/'
+        match = re.match(youtube_regex, url)
+        if match is not None:
+            return True
+
+        async with aiohttp.ClientSession() as session:
+            async with session.get(url) as resp:
+                final_url = str(resp.url)
+                match = re.match(youtube_regex, final_url)
+                return match is not None

--- a/models/check_model.py
+++ b/models/check_model.py
@@ -120,10 +120,13 @@ class Check:
 
         return inner
 
+
 class UrlCheck:
     @staticmethod
     async def check_youtube_link(url):
-        youtube_regex = r'(https?://)?(www\.)?(youtube|youtu|youtube-nocookie)\.(com|be)/'
+        youtube_regex = (
+            r"(https?://)?(www\.)?(youtube|youtu|youtube-nocookie)\.(com|be)/"
+        )
         match = re.match(youtube_regex, url)
         if match is not None:
             return True

--- a/models/index_model.py
+++ b/models/index_model.py
@@ -63,6 +63,7 @@ from llama_index.schema import BaseDocument
 
 from models.embed_statics_model import EmbedStatics
 from models.openai_model import Models
+from models.check_model import UrlCheck
 from services.environment_service import EnvService
 
 SHORT_TO_LONG_CACHE = {}
@@ -719,7 +720,7 @@ class Index_handler:
                 return
 
             # Check if the link contains youtube in it
-            if "youtube" in link:
+            if await UrlCheck.check_youtube_link(link):
                 index = await self.loop.run_in_executor(
                     None, partial(self.index_youtube_transcript, link, embedding_model)
                 )

--- a/models/index_model.py
+++ b/models/index_model.py
@@ -937,8 +937,7 @@ class Index_handler:
             )
 
             await self.usage_service.update_usage(
-                llm_predictor.last_token_usage,
-                "turbo"
+                llm_predictor.last_token_usage, "turbo"
             )
             await self.usage_service.update_usage(
                 embedding_model.last_token_usage, "embedding"
@@ -1087,7 +1086,7 @@ class Index_handler:
             print("The last token usage was ", llm_predictor.last_token_usage)
             await self.usage_service.update_usage(
                 llm_predictor.last_token_usage,
-                await self.usage_service.get_cost_name(model)
+                await self.usage_service.get_cost_name(model),
             )
             await self.usage_service.update_usage(
                 embedding_model.last_token_usage, "embedding"
@@ -1097,7 +1096,7 @@ class Index_handler:
                 total_price = round(
                     await self.usage_service.get_price(
                         llm_predictor.last_token_usage,
-                        await self.usage_service.get_cost_name(model)
+                        await self.usage_service.get_cost_name(model),
                     )
                     + await self.usage_service.get_price(
                         embedding_model.last_token_usage, "embedding"

--- a/models/index_model.py
+++ b/models/index_model.py
@@ -570,12 +570,12 @@ class Index_handler:
                         ),
                     )
                     await self.usage_service.update_usage(
-                        embedding_model.last_token_usage, embeddings=True
+                        embedding_model.last_token_usage, "embedding"
                     )
 
             try:
                 price = await self.usage_service.get_price(
-                    embedding_model.last_token_usage, embeddings=True
+                    embedding_model.last_token_usage, "embedding"
                 )
             except:
                 traceback.print_exc()
@@ -644,12 +644,12 @@ class Index_handler:
             )
 
             await self.usage_service.update_usage(
-                embedding_model.last_token_usage, embeddings=True
+                embedding_model.last_token_usage, "embedding"
             )
 
             try:
                 price = await self.usage_service.get_price(
-                    embedding_model.last_token_usage, embeddings=True
+                    embedding_model.last_token_usage, "embedding"
                 )
             except:
                 traceback.print_exc()
@@ -730,12 +730,12 @@ class Index_handler:
             else:
                 index = await self.index_webpage(link, embedding_model)
             await self.usage_service.update_usage(
-                embedding_model.last_token_usage, embeddings=True
+                embedding_model.last_token_usage, "embedding"
             )
 
             try:
                 price = await self.usage_service.get_price(
-                    embedding_model.last_token_usage, embeddings=True
+                    embedding_model.last_token_usage, "embedding"
                 )
             except:
                 traceback.print_exc()
@@ -790,13 +790,13 @@ class Index_handler:
             )
             try:
                 price = await self.usage_service.get_price(
-                    embedding_model.last_token_usage, embeddings=True
+                    embedding_model.last_token_usage, "embedding"
                 )
             except Exception:
                 traceback.print_exc()
                 price = "Unknown"
             await self.usage_service.update_usage(
-                embedding_model.last_token_usage, embeddings=True
+                embedding_model.last_token_usage, "embedding"
             )
             self.index_storage[ctx.user.id].add_index(index, ctx.user.id, channel.name)
             await ctx.respond(embed=EmbedStatics.get_index_set_success_embed(price))
@@ -912,9 +912,9 @@ class Index_handler:
             )
             total_usage_price = await self.usage_service.get_price(
                 llm_predictor_mock.last_token_usage,
-                chatgpt=True,  # TODO Enable again when tree indexes are fixed
+                "turbo",  # TODO Enable again when tree indexes are fixed
             ) + await self.usage_service.get_price(
-                embedding_model_mock.last_token_usage, embeddings=True
+                embedding_model_mock.last_token_usage, "embedding"
             )
             print("The total composition price is: ", total_usage_price)
             if total_usage_price > MAX_DEEP_COMPOSE_PRICE:
@@ -938,10 +938,10 @@ class Index_handler:
 
             await self.usage_service.update_usage(
                 llm_predictor.last_token_usage,
-                chatgpt=True,
+                "turbo"
             )
             await self.usage_service.update_usage(
-                embedding_model.last_token_usage, embeddings=True
+                embedding_model.last_token_usage, "embedding"
             )
 
             # Now we have a list of tree indexes, we can compose them
@@ -976,7 +976,7 @@ class Index_handler:
             )
 
             await self.usage_service.update_usage(
-                embedding_model.last_token_usage, embeddings=True
+                embedding_model.last_token_usage, "embedding"
             )
 
             if not name:
@@ -990,7 +990,7 @@ class Index_handler:
 
             try:
                 price = await self.usage_service.get_price(
-                    embedding_model.last_token_usage, embeddings=True
+                    embedding_model.last_token_usage, "embedding"
                 )
             except:
                 price = "Unknown"
@@ -1017,11 +1017,11 @@ class Index_handler:
                 None, partial(self.index_discord, document, embedding_model)
             )
             await self.usage_service.update_usage(
-                embedding_model.last_token_usage, embeddings=True
+                embedding_model.last_token_usage, "embedding"
             )
             try:
                 price = await self.usage_service.get_price(
-                    embedding_model.last_token_usage, embeddings=True
+                    embedding_model.last_token_usage, "embedding"
                 )
             except Exception:
                 traceback.print_exc()
@@ -1087,22 +1087,20 @@ class Index_handler:
             print("The last token usage was ", llm_predictor.last_token_usage)
             await self.usage_service.update_usage(
                 llm_predictor.last_token_usage,
-                chatgpt=True,
-                gpt4=True if model in Models.GPT4_MODELS else False,
+                await self.usage_service.get_cost_name(model)
             )
             await self.usage_service.update_usage(
-                embedding_model.last_token_usage, embeddings=True
+                embedding_model.last_token_usage, "embedding"
             )
 
             try:
                 total_price = round(
                     await self.usage_service.get_price(
                         llm_predictor.last_token_usage,
-                        chatgpt=True,
-                        gpt4=True if model in Models.GPT4_MODELS else False,
+                        await self.usage_service.get_cost_name(model)
                     )
                     + await self.usage_service.get_price(
-                        embedding_model.last_token_usage, embeddings=True
+                        embedding_model.last_token_usage, "embedding"
                     ),
                     6,
                 )

--- a/models/openai_model.py
+++ b/models/openai_model.py
@@ -1013,12 +1013,10 @@ class Model:
             data = aiohttp.FormData()
             data.add_field("model", "whisper-1")
             print("audio." + file.filename.split(".")[-1])
-            #TODO: make async
+            # TODO: make async
             data.add_field(
                 "file",
-                file.read()
-                if isinstance(file, discord.Attachment)
-                else file.fp.read(),
+                file.read() if isinstance(file, discord.Attachment) else file.fp.read(),
                 filename="audio." + file.filename.split(".")[-1]
                 if isinstance(file, discord.Attachment)
                 else "audio.mp4",

--- a/models/openai_model.py
+++ b/models/openai_model.py
@@ -83,8 +83,18 @@ class Models:
         GPT4_DEV,
         GPT4_32_DEV,
     ]
-    CHATGPT_MODELS = [TURBO, TURBO_16, TURBO_DEV, TURBO_16_DEV,]
-    GPT4_MODELS = [GPT4, GPT4_32, GPT4_DEV, GPT4_32_DEV,]
+    CHATGPT_MODELS = [
+        TURBO,
+        TURBO_16,
+        TURBO_DEV,
+        TURBO_16_DEV,
+    ]
+    GPT4_MODELS = [
+        GPT4,
+        GPT4_32,
+        GPT4_DEV,
+        GPT4_32_DEV,
+    ]
     EDIT_MODELS = [EDIT]
 
     DEFAULT = TURBO
@@ -192,7 +202,9 @@ class Model:
             else 100000
         )  # The maximum number of conversation items to keep in memory
         self.model = (
-            SETTINGS_DB["model"] if "model" in SETTINGS_DB and SETTINGS_DB["model"] in Models.TEXT_MODELS else Models.DEFAULT
+            SETTINGS_DB["model"]
+            if "model" in SETTINGS_DB and SETTINGS_DB["model"] in Models.TEXT_MODELS
+            else Models.DEFAULT
         )
         self._low_usage_mode = False
         self.usage_service = usage_service
@@ -640,8 +652,7 @@ class Model:
                 pass
             else:
                 await self.usage_service.update_usage(
-                    tokens_used,
-                    await self.usage_service.get_cost_name(model)
+                    tokens_used, await self.usage_service.get_cost_name(model)
                 )
         except Exception as e:
             traceback.print_exc()

--- a/models/openai_model.py
+++ b/models/openai_model.py
@@ -51,8 +51,6 @@ class Models:
     # Text models
     DAVINCI = "text-davinci-003"
     CURIE = "text-curie-001"
-    BABBAGE = "text-babbage-001"
-    ADA = "text-ada-001"
 
     # Embedding models
     EMBEDDINGS = "text-embedding-ada-002"
@@ -62,40 +60,48 @@ class Models:
 
     # ChatGPT Models
     TURBO = "gpt-3.5-turbo"
-    TURBO_DEV = "gpt-3.5-turbo-0301"
+    TURBO_16 = "gpt-3.5-turbo-16k"
+    TURBO_DEV = "gpt-3.5-turbo-0613"
+    TURBO_16_DEV = "gpt-3.5-turbo-16k-0613"
 
     # GPT4 Models
     GPT4 = "gpt-4"
     GPT4_32 = "gpt-4-32k"
+    GPT4_DEV = "gpt-4-0613"
+    GPT4_32_DEV = "gpt-4-32k-0613"
 
     # Model collections
     TEXT_MODELS = [
         DAVINCI,
         CURIE,
-        BABBAGE,
-        ADA,
         TURBO,
+        TURBO_16,
         TURBO_DEV,
+        TURBO_16_DEV,
         GPT4,
         GPT4_32,
+        GPT4_DEV,
+        GPT4_32_DEV,
     ]
-    CHATGPT_MODELS = [TURBO, TURBO_DEV]
-    GPT4_MODELS = [GPT4, GPT4_32]
+    CHATGPT_MODELS = [TURBO, TURBO_16, TURBO_DEV, TURBO_16_DEV,]
+    GPT4_MODELS = [GPT4, GPT4_32, GPT4_DEV, GPT4_32_DEV,]
     EDIT_MODELS = [EDIT]
 
-    DEFAULT = DAVINCI
+    DEFAULT = TURBO
     LOW_USAGE_MODEL = CURIE
 
     # Tokens Mapping
     TOKEN_MAPPING = {
-        "text-davinci-003": 4024,
-        "text-curie-001": 2024,
-        "text-babbage-001": 2024,
-        "text-ada-001": 2024,
+        DAVINCI: 4024,
+        CURIE: 2024,
         TURBO: 4096,
+        TURBO_16: 16384,
         TURBO_DEV: 4096,
+        TURBO_16_DEV: 16384,
         GPT4: 8192,
         GPT4_32: 32768,
+        GPT4_DEV: 8192,
+        GPT4_32_DEV: 32768,
     }
 
     @staticmethod
@@ -186,8 +192,8 @@ class Model:
             else 100000
         )  # The maximum number of conversation items to keep in memory
         self.model = (
-            SETTINGS_DB["model"] if "model" in SETTINGS_DB else Models.DEFAULT
-        )  # The model to use
+            SETTINGS_DB["model"] if "model" in SETTINGS_DB and SETTINGS_DB["model"] in Models.TEXT_MODELS else Models.DEFAULT
+        )
         self._low_usage_mode = False
         self.usage_service = usage_service
         self.DAVINCI_ROLES = ["admin", "Admin", "GPT", "gpt"]
@@ -630,17 +636,13 @@ class Model:
     async def valid_text_request(self, response, model=None):
         try:
             tokens_used = int(response["usage"]["total_tokens"])
-            if model and model in Models.GPT4_MODELS:
-                await self.usage_service.update_usage(
-                    tokens_used,
-                    prompt_tokens=int(response["usage"]["prompt_tokens"]),
-                    completion_tokens=int(response["usage"]["completion_tokens"]),
-                    gpt4=True,
-                )
             if model and model in Models.EDIT_MODELS:
                 pass
             else:
-                await self.usage_service.update_usage(tokens_used)
+                await self.usage_service.update_usage(
+                    tokens_used,
+                    await self.usage_service.get_cost_name(model)
+                )
         except Exception as e:
             traceback.print_exc()
             if "error" in response:

--- a/models/openai_model.py
+++ b/models/openai_model.py
@@ -1013,11 +1013,12 @@ class Model:
             data = aiohttp.FormData()
             data.add_field("model", "whisper-1")
             print("audio." + file.filename.split(".")[-1])
+            #TODO: make async
             data.add_field(
                 "file",
-                await file.read()
+                file.read()
                 if isinstance(file, discord.Attachment)
-                else await file.fp.read(),
+                else file.fp.read(),
                 filename="audio." + file.filename.split(".")[-1]
                 if isinstance(file, discord.Attachment)
                 else "audio.mp4",

--- a/models/search_model.py
+++ b/models/search_model.py
@@ -215,7 +215,7 @@ class Search:
         nodes,
         deep,
         response_mode,
-        model="gpt-3.5-turbo",
+        model,
         multistep=False,
         redo=None,
     ):
@@ -251,10 +251,10 @@ class Search:
             query_refined_text = query_refined.generations[0][0].text
 
             await self.usage_service.update_usage(
-                query_refined.llm_output.get("token_usage").get("total_tokens")
+                query_refined.llm_output.get("token_usage").get("total_tokens"), "davinci"
             )
             price += await self.usage_service.get_price(
-                query_refined.llm_output.get("token_usage").get("total_tokens")
+                query_refined.llm_output.get("token_usage").get("total_tokens"), "davinci"
             )
 
         except Exception as e:
@@ -360,7 +360,7 @@ class Search:
             ),
         )
         total_usage_price = await self.usage_service.get_price(
-            embed_model_mock.total_tokens_used, embeddings=True
+            embed_model_mock.total_tokens_used, "embedding"
         )
         if total_usage_price > 1.00:
             raise ValueError(
@@ -484,24 +484,22 @@ class Search:
 
         await self.usage_service.update_usage(
             service_context.llm_predictor.total_tokens_used,
-            chatgpt=True,
-            gpt4=True if model in Models.GPT4_MODELS else False,
+            await self.usage_service.get_cost_name(model)
         )
         await self.usage_service.update_usage(
-            service_context.embed_model.total_tokens_used, embeddings=True
+            service_context.embed_model.total_tokens_used, "embedding"
         )
         price += await self.usage_service.get_price(
             service_context.llm_predictor.total_tokens_used,
-            chatgpt=True,
-            gpt4=True if model in Models.GPT4_MODELS else False,
+            await self.usage_service.get_cost_name(model)
         ) + await self.usage_service.get_price(
-            service_context.embed_model.total_tokens_used, embeddings=True
+            service_context.embed_model.total_tokens_used, "embedding"
         )
 
         if ctx:
             await self.try_edit(
                 in_progress_message,
-                self.build_search_final_embed(query_refined_text, str(price)),
+                self.build_search_final_embed(query_refined_text, str(round(price, 6))),
             )
 
         return response, query_refined_text

--- a/models/search_model.py
+++ b/models/search_model.py
@@ -251,10 +251,12 @@ class Search:
             query_refined_text = query_refined.generations[0][0].text
 
             await self.usage_service.update_usage(
-                query_refined.llm_output.get("token_usage").get("total_tokens"), "davinci"
+                query_refined.llm_output.get("token_usage").get("total_tokens"),
+                "davinci",
             )
             price += await self.usage_service.get_price(
-                query_refined.llm_output.get("token_usage").get("total_tokens"), "davinci"
+                query_refined.llm_output.get("token_usage").get("total_tokens"),
+                "davinci",
             )
 
         except Exception as e:
@@ -484,14 +486,14 @@ class Search:
 
         await self.usage_service.update_usage(
             service_context.llm_predictor.total_tokens_used,
-            await self.usage_service.get_cost_name(model)
+            await self.usage_service.get_cost_name(model),
         )
         await self.usage_service.update_usage(
             service_context.embed_model.total_tokens_used, "embedding"
         )
         price += await self.usage_service.get_price(
             service_context.llm_predictor.total_tokens_used,
-            await self.usage_service.get_cost_name(model)
+            await self.usage_service.get_cost_name(model),
         ) + await self.usage_service.get_price(
             service_context.embed_model.total_tokens_used, "embedding"
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ dependencies = [
 "pytest~=7.2.2",
 "google-api-python-client==2.85.0",
 "wolframalpha==5.0.0",
+"nltk==3.8.1",
 "replicate==0.8.1",
 "tiktoken==0.4.0"
 ]
@@ -69,7 +70,6 @@ full = [
   "tokenizers==0.13.3",
   "numpy==1.24.2",
   "scipy==1.10.1",
-  "nltk==3.8.1",
   "huggingface-hub==0.12.1",
   "more-itertools==9.0.0",
   "ffmpeg-python==0.2.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,8 @@ classifiers = [
 dependencies = [
 "Pillow==9.3.0",
 "openai==0.27.8",
-"pytube==12.1.2",
+"yt-dlp==2023.3.4",
+"ffmpeg==1.4",
 "beautifulsoup4==4.11.2",
 "py-cord==2.4.1",
 "python-dotenv==1.0.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 Pillow==9.3.0
 openai==0.27.8
-pytube==12.1.2
+yt-dlp==2023.3.4
+ffmpeg==1.4
 py-cord==2.4.1
 beautifulsoup4==4.11.2
 python-dotenv==1.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,5 +29,6 @@ pytest-asyncio==0.21.0
 pytest~=7.2.2
 google-api-python-client==2.85.0
 wolframalpha==5.0.0
+nltk==3.8.1
 replicate==0.8.1
 tiktoken==0.4.0

--- a/requirements_base.txt
+++ b/requirements_base.txt
@@ -1,6 +1,7 @@
 Pillow==9.3.0
 openai==0.27.0
-pytube==12.1.2
+yt-dlp==2023.3.4
+ffmpeg==1.4
 py-cord==2.4.1
 beautifulsoup4==4.11.2
 python-dotenv==1.0.0

--- a/requirements_base.txt
+++ b/requirements_base.txt
@@ -27,5 +27,6 @@ pytest-asyncio==0.21.0
 pytest~=7.2.2
 google-api-python-client==2.85.0
 wolframalpha==5.0.0
+nltk==3.8.1
 replicate==0.8.1
 tiktoken==0.4.0

--- a/requirements_full.txt
+++ b/requirements_full.txt
@@ -1,7 +1,6 @@
 tokenizers==0.13.3
 numpy==1.24.2
 scipy==1.10.1
-nltk==3.8.1
 huggingface-hub==0.12.1
 more-itertools==9.0.0
 ffmpeg-python==0.2.0

--- a/services/text_service.py
+++ b/services/text_service.py
@@ -920,11 +920,11 @@ class TextService:
                 ].get_overrides()
 
                 overrides = Override(
-                conversation_overrides["temperature"],
-                conversation_overrides["top_p"],
-                conversation_overrides["frequency_penalty"],
-                conversation_overrides["presence_penalty"],
-            )
+                    conversation_overrides["temperature"],
+                    conversation_overrides["top_p"],
+                    conversation_overrides["frequency_penalty"],
+                    conversation_overrides["presence_penalty"],
+                )
 
                 await TextService.encapsulated_send(
                     converser_cog,

--- a/services/text_service.py
+++ b/services/text_service.py
@@ -883,7 +883,7 @@ class TextService:
     @staticmethod
     async def process_conversation_edit(converser_cog, after, original_message):
         if after.author.id in converser_cog.redo_users:
-            if after.id == original_message[after.author.id]:
+            if after.id == original_message.get(after.author.id, None):
                 response_message = converser_cog.redo_users[after.author.id].response
                 ctx = converser_cog.redo_users[after.author.id].ctx
                 await response_message.edit(content="Redoing prompt 🔄...")

--- a/services/text_service.py
+++ b/services/text_service.py
@@ -915,9 +915,16 @@ class TextService:
 
                     converser_cog.conversation_threads[after.channel.id].count += 1
 
-                overrides = converser_cog.conversation_threads[
+                conversation_overrides = converser_cog.conversation_threads[
                     after.channel.id
                 ].get_overrides()
+
+                overrides = Override(
+                conversation_overrides["temperature"],
+                conversation_overrides["top_p"],
+                conversation_overrides["frequency_penalty"],
+                conversation_overrides["presence_penalty"],
+            )
 
                 await TextService.encapsulated_send(
                     converser_cog,
@@ -925,10 +932,7 @@ class TextService:
                     prompt=edited_content,
                     ctx=ctx,
                     response_message=response_message,
-                    temp_override=overrides["temperature"],
-                    top_p_override=overrides["top_p"],
-                    frequency_penalty_override=overrides["frequency_penalty"],
-                    presence_penalty_override=overrides["presence_penalty"],
+                    overrides=overrides,
                     model=converser_cog.conversation_threads[after.channel.id].model,
                     edited_request=True,
                 )

--- a/services/usage_service.py
+++ b/services/usage_service.py
@@ -43,17 +43,16 @@ class UsageService:
     @staticmethod
     async def get_model_cost(mode: ModeType) -> float:
         return UsageService.COST_MAPPING.get(mode, 0)
+
     @staticmethod
     async def get_cost_name(model) -> str:
         return UsageService.MODEL_COST_MAP.get(model, "davinci")
-    
-    async def get_price(
-        self,
-        tokens_used,
-        mode: ModeType = None
-    ):
+
+    async def get_price(self, tokens_used, mode: ModeType = None):
         tokens_used = int(tokens_used)
-        price = (tokens_used / 1000) * await self.get_model_cost(mode)  # This is a very rough estimate
+        price = (tokens_used / 1000) * await self.get_model_cost(
+            mode
+        )  # This is a very rough estimate
         price = round(price, 6)
         return price
 

--- a/services/usage_service.py
+++ b/services/usage_service.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 import aiofiles
+from typing import Literal
 from transformers import GPT2TokenizerFast
 
 
@@ -14,54 +15,61 @@ class UsageService:
                 f.close()
         self.tokenizer = GPT2TokenizerFast.from_pretrained("gpt2")
 
+    COST_MAPPING = {
+        "gpt4": 0.05,
+        "gpt4-32": 0.1,
+        "turbo": 0.0019,
+        "turbo-16": 0.0038,
+        "davinci": 0.02,
+        "curie": 0.002,
+        "embedding": 0.0001,
+    }
+
+    MODEL_COST_MAP = {
+        "gpt-4": "gpt4",
+        "gpt-4-32k": "gpt4-32",
+        "gpt-4-0613": "gpt4",
+        "gpt-4-32k-0613": "gpt4-32",
+        "gpt-3.5-turbo": "turbo",
+        "gpt-3.5-turbo-16k": "turbo-16",
+        "gpt-3.5-turbo-0613": "turbo",
+        "gpt-3.5-turbo-16k-0613": "turbo",
+        "text-davinci-003": "davinci",
+        "text-curie-001": "curie",
+    }
+
+    ModeType = Literal["gpt4", "gpt4-32k", "turbo", "turbo-16k", "davinci", "embedding"]
+
+    @staticmethod
+    async def get_model_cost(mode: ModeType) -> float:
+        return UsageService.COST_MAPPING.get(mode, 0)
+    @staticmethod
+    async def get_cost_name(model) -> str:
+        return UsageService.MODEL_COST_MAP.get(model, "davinci")
+    
     async def get_price(
         self,
         tokens_used,
-        prompt_tokens=None,
-        completion_tokens=None,
-        embeddings=False,
-        chatgpt=False,
-        gpt4=False,
+        mode: ModeType = None
     ):
         tokens_used = int(tokens_used)
-        if gpt4:
-            price = (tokens_used / 1000) * 0.05  # This is a very rough estimate
-            return price
-        elif chatgpt:
-            price = (tokens_used / 1000) * 0.002
-            return price
-        elif not embeddings:
-            price = (tokens_used / 1000) * 0.02
-        else:
-            price = (tokens_used / 1000) * 0.0004
+        price = (tokens_used / 1000) * await self.get_model_cost(mode)  # This is a very rough estimate
         price = round(price, 6)
         return price
 
     async def update_usage(
         self,
         tokens_used,
-        prompt_tokens=None,
-        completion_tokens=None,
-        embeddings=False,
-        chatgpt=False,
-        gpt4=False,
+        mode: ModeType = None,
     ):
         tokens_used = int(tokens_used)
-        if gpt4:
-            price = (tokens_used / 1000) * 0.05  # This is a very rough estimate..
-        elif chatgpt:
-            price = (tokens_used / 1000) * 0.002
-        elif not embeddings:
-            price = (tokens_used / 1000) * 0.02
-        else:
-            price = (tokens_used / 1000) * 0.0004
+        price = (tokens_used / 1000) * await self.get_model_cost(mode)
         price = round(price, 6)
         usage = round(await self.get_usage(), 6)
         new_total = round(usage + price, 6)
         print(
-            f"{'Completion' if not embeddings else 'Embed'} cost -> Old: {str(usage)} | New: {str(new_total)}, used {str(price)} credits"
+            f"{'Completion' if mode != 'embedding' else 'Embed'} cost -> Old: {str(usage)} | New: {str(new_total)}, used {str(price)} credits"
         )
-        # Do the same as above but with aiofiles
         async with aiofiles.open(self.usage_file_path, "w") as f:
             await f.write(str(new_total))
             await f.close()

--- a/services/usage_service.py
+++ b/services/usage_service.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 import aiofiles
 from typing import Literal
-from transformers import GPT2TokenizerFast
+import tiktoken
 
 
 class UsageService:
@@ -13,7 +13,7 @@ class UsageService:
             with self.usage_file_path.open("w") as f:
                 f.write("0.00")
                 f.close()
-        self.tokenizer = GPT2TokenizerFast.from_pretrained("gpt2")
+        self.tokenizer = tiktoken.get_encoding("cl100k_base")
 
     COST_MAPPING = {
         "gpt4": 0.05,
@@ -85,7 +85,7 @@ class UsageService:
         return usage
 
     def count_tokens(self, text):
-        res = self.tokenizer(text)["input_ids"]
+        res = self.tokenizer.encode(text)
         return len(res)
 
     async def update_usage_image(self, image_size):
@@ -110,6 +110,6 @@ class UsageService:
 
     @staticmethod
     def count_tokens_static(text):
-        tokenizer = GPT2TokenizerFast.from_pretrained("gpt2")
-        res = tokenizer(text)["input_ids"]
+        tokenizer = tiktoken.get_encoding("cl100k_base")
+        res = tokenizer.encode(text)
         return len(res)


### PR DESCRIPTION
Fixes #316 #312 

- Fix a recurring error message related to KeyError due to the user being in redo_users but doesn't have an original_message entry.
- Enable the usage of the newly updated models. More turbo and gpt4 models to pick from for index and search. Set default model if the one in the db is not in TEXT_MODELS on restart. Refactored the usage service. Removed babbage and ada.
- Add support for shortened youtube links. Replaced pytube with yt-dpl for transcription. Added youtube link validation and redirect check. Removed await on .read() in openai_model as those functions aren't async.
- Move the nltk dependency in the requirements files.
- Fix the web crawling part of the internet chat. Made the limit dynamic based on model for when to index the website.
- Switch to counting tokens with tiktoken.