### PR TITLE
Add pypdf dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
 "backoff==2.2.1",
 "flask==2.2.3",
 "llama-index==0.6.30",
-"PyPDF2==3.0.1",
+"pypdf==3.11.1",
 "youtube_transcript_api==0.5.0",
 "sentencepiece==0.1.99",
 "protobuf==3.20.2",

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ sqlitedict==2.1.0
 backoff==2.2.1
 flask==2.2.3
 llama-index==0.6.30
-PyPDF2==3.0.1
+pypdf==3.11.1
 youtube_transcript_api==0.5.0
 sentencepiece==0.1.99
 protobuf==3.20.2

--- a/requirements_base.txt
+++ b/requirements_base.txt
@@ -14,7 +14,7 @@ sqlitedict==2.1.0
 backoff==2.2.1
 flask==2.2.3
 llama-index==0.6.30
-PyPDF2==3.0.1
+pypdf==3.11.1
 youtube_transcript_api==0.5.0
 sentencepiece==0.1.99
 protobuf==3.20.2


### PR DESCRIPTION
Removed PyPDF2, deprecated
Fixes #332 