### PR TITLE
Defer "Conversation started" messages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,5 +13,4 @@ usage.txt
 /audiotemp
 /pickles
 .idea
-
-
+venv/

--- a/cogs/code_interpreter_service_cog.py
+++ b/cogs/code_interpreter_service_cog.py
@@ -386,6 +386,7 @@ class CodeInterpreterService(discord.Cog, name="CodeInterpreterService"):
         ctx: discord.ApplicationContext,
         model,
     ):
+        await ctx.defer()
         embed_title = f"{ctx.user.name}'s code interpreter conversation with GPT"
         message_embed = discord.Embed(
             title=embed_title,

--- a/cogs/search_service_cog.py
+++ b/cogs/search_service_cog.py
@@ -421,6 +421,7 @@ class SearchService(discord.Cog, name="SearchService"):
     async def search_chat_command(
         self, ctx: discord.ApplicationContext, model, search_scope=2
     ):
+        await ctx.defer()
         embed_title = f"{ctx.user.name}'s internet-connected conversation with GPT"
         message_embed = discord.Embed(
             title=embed_title,

--- a/cogs/text_service_cog.py
+++ b/cogs/text_service_cog.py
@@ -1158,7 +1158,7 @@ class GPT3ComCon(discord.Cog, name="GPT3ComCon"):
             frequency_penalty (float): Sets the frequency penalty override
             presence_penalty (float): Sets the presence penalty override
         """
-
+        await ctx.defer(ephemeral=private)
         user = ctx.user
 
         # If we are in user input api keys mode, check if the user has entered their api key before letting them continue

--- a/models/index_model.py
+++ b/models/index_model.py
@@ -508,6 +508,7 @@ class Index_handler:
                     return False, None
 
     async def start_index_chat(self, ctx, model):
+        await ctx.defer()
         preparation_message = await ctx.channel.send(
             embed=EmbedStatics.get_index_chat_preparation_message()
         )

--- a/utils/safe_ctx_respond.py
+++ b/utils/safe_ctx_respond.py
@@ -15,9 +15,9 @@ async def safe_ctx_respond(
     Safely responds to a Discord interaction.
 
     Args:
-        *args: Positional arguments to be passed to the `respond` or `reply` method of the context.
-        **kwargs: Keyword arguments to be passed to the `respond` or `reply` method of the context.
-            `ctx` is a required keyword argument.
+        ctx (discord.ApplicationContext): The interaction context.
+        content (str): The content to send.
+        ephemeral (bool, optional): Whether the response should be ephemeral. Defaults to False.
 
     Raises:
         ValueError: If `ctx` is not provided in the `kwargs`.


### PR DESCRIPTION
Defer the messages saying "Conversation started", and update the docstring of "safe_cxt_respond" to reflect the updated parameters. Add venv/ in .gitignore.