### PR TITLE
Fix missing utils when running via Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,6 +41,7 @@ COPY README.md /src
 COPY cogs /src/cogs
 COPY models /src/models
 COPY services /src/services
+COPY utils /src/utils
 COPY gpt3discord.py /src
 COPY pyproject.toml /src
 


### PR DESCRIPTION
Fixes the following error when running from Docker:

```
  File "/opt/gpt3discord/bin/gpt3discord.py", line 14, in <module>
    from cogs.code_interpreter_service_cog import CodeInterpreterService
  File "/usr/local/lib/python3.10/site-packages/cogs/code_interpreter_service_cog.py", line 38, in <module>
    from utils.safe_ctx_respond import safe_ctx_respond, safe_remove_list
ModuleNotFoundError: No module named 'utils'
```