### PR TITLE
Kashifb/qdrant migration

### DIFF
--- a/cogs/text_service_cog.py
+++ b/cogs/text_service_cog.py
@@ -87,7 +87,7 @@ class GPT3ComCon(discord.Cog, name="GPT3ComCon"):
         DEBUG_GUILD,
         DEBUG_CHANNEL,
         data_path: Path,
-        pinecone_service,
+        qdrant_service,
         pickle_queue,
     ):
         super().__init__()
@@ -126,8 +126,11 @@ class GPT3ComCon(discord.Cog, name="GPT3ComCon"):
         self.instructions = defaultdict(list)
         self.summarize = self.model.summarize_conversations
 
+        
         # Pinecone data
-        self.pinecone_service = pinecone_service
+        # self.pinecone_service = pinecone_service
+        
+        self.qdrant_service = qdrant_service
 
         # Sharing service
         self.sharegpt_service = ShareGPTService()
@@ -1380,7 +1383,7 @@ class GPT3ComCon(discord.Cog, name="GPT3ComCon"):
                 )
             if target.id in self.conversation_threads:
                 self.awaiting_responses.append(user_id_normalized)
-                if not self.pinecone_service:
+                if not self.qdrant_service:
                     self.conversation_threads[target.id].history.append(
                         EmbeddedConversationItem(
                             f"\n{ctx.author.display_name}: {opener} <|endofstatement|>\n",
@@ -1404,7 +1407,7 @@ class GPT3ComCon(discord.Cog, name="GPT3ComCon"):
                 (
                     opener
                     if target.id not in self.conversation_threads
-                    or self.pinecone_service
+                    or self.qdrant_service
                     else "".join(
                         [
                             item.text

--- a/gpt3discord.py
+++ b/gpt3discord.py
@@ -33,6 +33,9 @@ from services.environment_service import EnvService
 
 from models.openai_model import Model
 
+from qdrant_client import QdrantClient
+from services.qdrant_service import QdrantService
+
 
 __version__ = "12.3.8"
 
@@ -70,6 +73,26 @@ if PINECONE_TOKEN:
     pinecone_service = PineconeService(pinecone.Index(PINECONE_INDEX))
     print("Got the pinecone service")
 
+try: 
+    QDRANT_TOKEN = os.getenv("QDRANT_TOKEN")
+    QDRANT_URL = os.getenv("QDRANT_CLUSTER_URL")
+except Exception:
+    QDRANT_TOKEN = None
+    QDRANT_URL = None
+
+qdrant_service = None
+if QDRANT_TOKEN and QDRANT_URL:
+    qdrant_client = QdrantClient(
+    url= QDRANT_URL, 
+    api_key=QDRANT_TOKEN,
+    )
+    qdrant_service = QdrantService(qdrant_client)
+    # Check if conversation-embeddings collection already exists, else make one
+    collections = qdrant_client.get_collections().collections
+    if not any(collection.name == "conversation-embeddings" for collection in collections):
+        qdrant_service.make_collection()
+    print("Got the Qdrant service")
+    
 #
 # Message queueing for the debug service, defer debug messages to be sent later so we don't hit rate limits.
 #
@@ -143,7 +166,7 @@ async def main():
             debug_guild,
             debug_channel,
             data_path,
-            pinecone_service=pinecone_service,
+            qdrant_service = qdrant_service,
             pickle_queue=pickle_queue,
         )
     )

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,3 +35,4 @@ replicate==0.15.4
 tiktoken==0.4.0
 pydantic==2.4.2
 e2b==0.10.6
+qdrant-client

--- a/sample.env
+++ b/sample.env
@@ -13,6 +13,8 @@ OPENAI_TOKEN = "<openai_api_token>"
 DISCORD_TOKEN = "<discord_bot_token>"
 ## PINECONE_TOKEN = "<pinecone_token>" # pinecone token, if you have it enabled. See readme
 ## PINECONE_REGION = "<pinecone_region>" # add your region here if it's not us-west1-gcp
+QDRANT_TOKEN = "<qdrant_cluster_token>"
+QDRANT_CLUSTER_URL = "<qdrant_cluster_url>"
 ## GOOGLE_SEARCH_API_KEY = "<google_api_key>" # allows internet searches and chats
 ## GOOGLE_SEARCH_ENGINE_ID = "<google_engine_id>" # allows internet searches and chats
 ## DEEPL_TOKEN = "<deepl_token>" # allows human language translations from DeepL API
@@ -25,10 +27,10 @@ DISCORD_TOKEN = "<discord_bot_token>"
 ### DISCORD SERVER/CHANNEL CONFIGURATION
 ################################################################################
 
-DEBUG_GUILD = "974519864045756446"  # discord_server_id for debug messages
-DEBUG_CHANNEL = "977697652147892304"  # discord_chanel_id where the messages will be posted
-ALLOWED_GUILDS = "971268468148166697,971268468148166697"  # server ids where the bot should add its commands
-MODERATIONS_ALERT_CHANNEL = "977697652147892304"  # Moderations Service alert channel, this is where moderation alerts will be sent as a default if enabled
+DEBUG_GUILD = "<discord_server_id>"  # discord_server_id for debug messages
+DEBUG_CHANNEL = "<discord_chanel_id>"  # discord_chanel_id where the messages will be posted
+ALLOWED_GUILDS = "<discord_server_id>"  # server ids where the bot should add its commands
+MODERATIONS_ALERT_CHANNEL = "<discord_chanel_id>"  # Moderations Service alert channel, this is where moderation alerts will be sent as a default if enabled
 
 ################################################################################
 ### ROLE PERMISSIONS

--- a/services/qdrant_service.py
+++ b/services/qdrant_service.py
@@ -1,0 +1,74 @@
+from qdrant_client import QdrantClient
+from qdrant_client.models import Distance, VectorParams
+from qdrant_client.http import models
+import uuid
+
+class QdrantService:
+    def __init__(self, client: QdrantClient):
+        self.client = client
+    
+    def make_collection(self):
+        self.client.create_collection(
+            collection_name="conversation-embeddings",
+            vectors_config=VectorParams(size=1536, distance=Distance.COSINE))
+    
+    def upsert_basic(self, text, embedding, conversation_id: int, timestamp):
+        self.client.upsert(
+            collection_name = "conversation-embeddings",
+            points = [
+                models.PointStruct(
+                    # Can't upsert the text as the ID like pinecone, use a random UUID instead and add text as a payload
+                    id= str(uuid.uuid4()),
+                    payload={
+                        "text" : text,
+                        "conversation_id" : conversation_id,
+                        "timestamp" : timestamp,
+                    },
+                    vector= embedding,
+                )
+            ]
+        )
+
+    async def upsert_conversation_embedding(self, model, conversation_id:int, text, timestamp, custom_api_key=None):
+        first_embedding = None
+        if len(text) > 500:
+            # Split the text into 512 character chunks
+            chunks = [text[i : i + 500] for i in range(0, len(text), 500)]
+            for chunk in chunks:
+                # Create an embedding for the split chunk
+                embedding = await model.send_embedding_request(
+                    chunk, custom_api_key=custom_api_key
+                )
+                if not first_embedding:
+                    first_embedding = embedding
+                self.upsert_basic(chunk, embedding, conversation_id, timestamp)
+            return first_embedding
+        embedding = await model.send_embedding_request(
+            text, custom_api_key=custom_api_key
+        )
+        self.upsert_basic(text, embedding, conversation_id, timestamp)
+        return embedding
+    
+    def get_n_similar(self, conversation_id: int, embedding, n=10):
+        response = self.client.search(
+            collection_name= "conversation-embeddings",
+            query_filter=models.Filter(
+                must=[
+                    models.FieldCondition(
+                        key="conversation_id",
+                        match = models.MatchValue(
+                            value=conversation_id,
+                        ),
+                    )
+                ]
+            ),
+            query_vector=embedding,
+            with_payload=["text", "timestamp"],
+            limit = n,
+        )
+        relevant_phrases = [
+            (match.payload["text"], match.payload["timestamp"])
+            for match in response
+        ]
+        return relevant_phrases
+


### PR DESCRIPTION
 Switched from Pinecone to Qdrant database

Summary:
-The new Qdrant services (in qdrant_service.py)
just mirrors the old Pinecone services
-Replaced all instances of Pinecone use in
text_service_cog with qdrant
-Added QDRANT_TOKEN and QDRANT_URL tokens in sample.env

Possible changes:
-Keep Pinecone functionality in text_service_cog, offer a choice in which database to use
-Add a READMe detailing how to create a Qdrant cluster, collection, etc. (fairly simple process)

