### PR TITLE
Add comprehensive GPT model support - Fix issue #475

### DIFF
--- a/cogs/code_interpreter_service_cog.py
+++ b/cogs/code_interpreter_service_cog.py
@@ -32,6 +32,7 @@ from langchain.schema import SystemMessage
 from langchain.utilities import GoogleSearchAPIWrapper
 
 from models.embed_statics_model import EmbedStatics
+from models.openai_model import Models
 from services.deletion_service import Deletion
 from services.environment_service import EnvService
 from services.moderations_service import Moderation
@@ -467,13 +468,15 @@ class CodeInterpreterService(discord.Cog, name="CodeInterpreterService"):
             openai_api_key=OPENAI_API_KEY,
         )
 
-        max_token_limit = 29000 if "gpt-4" in model else 7500
+        # Ensure all GPT-4 models (including GPT-4o variants) are treated correctly for token limit settings
+        is_gpt4_model = Models.is_gpt4_model(model)
+        max_token_limit = 29000 if is_gpt4_model else 7500
 
         memory = ConversationSummaryBufferMemory(
             memory_key="memory",
             return_messages=True,
             llm=llm,
-            max_token_limit=100000 if "preview" in model else max_token_limit,
+            max_token_limit=100000 if Models.is_high_context_model(model) else max_token_limit,
         )
 
         agent_kwargs = {

--- a/cogs/prompt_optimizer_cog.py
+++ b/cogs/prompt_optimizer_cog.py
@@ -95,9 +95,8 @@ class ImgPromptOptimizer(discord.Cog, name="ImgPromptOptimizer"):
                 presence_penalty_override=0.5,
                 best_of_override=1,
                 max_tokens_override=60,
-                custom_api_key=user_api_key,
-                is_chatgpt_request="turbo" in str(self.model.model)
-                or "gpt-4" in str(self.model.model),
+                custom_api_key=user_api_key,                is_chatgpt_request=Models.is_gpt4_model(str(self.model.model))
+                or "turbo" in str(self.model.model),
             )
 
             # THIS USES MORE TOKENS THAN A NORMAL REQUEST! This will use roughly 4000 tokens, and will repeat the query

--- a/cogs/search_service_cog.py
+++ b/cogs/search_service_cog.py
@@ -489,13 +489,15 @@ class SearchService(discord.Cog, name="SearchService"):
             openai_api_key=OPENAI_API_KEY,
         )
 
-        max_token_limit = 29000 if "gpt-4" in model else 7500
+        # Ensure all GPT-4 models (including GPT-4o variants) are treated correctly for token limit settings
+        is_gpt4_model = Models.is_gpt4_model(model)
+        max_token_limit = 29000 if is_gpt4_model else 7500
 
         memory = ConversationSummaryBufferMemory(
             memory_key="memory",
             return_messages=True,
             llm=llm,
-            max_token_limit=100000 if "preview" in model else max_token_limit,
+            max_token_limit=100000 if Models.is_high_context_model(model) else max_token_limit,
         )
 
         agent_kwargs = {

--- a/models/autocomplete_model.py
+++ b/models/autocomplete_model.py
@@ -88,17 +88,22 @@ class Settings_autocompleter:
         return []
 
     async def get_function_calling_models(ctx: discord.AutocompleteContext):
+        # Use centralized model definitions for function calling models
         return [
-            "gpt-4",
-            "gpt-4-32k",
-            "gpt-4-1106-preview",
-            "gpt-4-0613",
-            "gpt-3.5-turbo",
-            "gpt-3.5-turbo-1106",
-            "gpt-3.5-turbo-0613",
-            "gpt-4-turbo-preview",
-            "gpt-4-turbo",
-            "gpt-4o",
+            Models.GPT4,
+            Models.GPT4_32,
+            Models.GPT_4_TURBO_REGULAR,
+            Models.GPT4_DEV,
+            Models.TURBO,
+            Models.TURBO_0125,
+            Models.TURBO_DEV,
+            Models.GPT_4_TURBO,
+            Models.GPT_4_TURBO_2024_04_09,
+            Models.GPT_4_OMEGA,
+            Models.GPT_4_OMEGA_2024_05_13,
+            Models.GPT_4_OMEGA_2024_08_06,
+            Models.GPT_4_OMEGA_MINI,
+            Models.GPT_4_OMEGA_MINI_2024_07_18,
         ]
 
     async def get_models(

--- a/services/text_service.py
+++ b/services/text_service.py
@@ -322,11 +322,11 @@ class TextService:
                 and not from_edit_command
                 and (
                     (
-                        model is not None
-                        and (
-                            model in Models.CHATGPT_MODELS
-                            or (model == "chatgpt" or "gpt-4" in model)
-                        )
+                        model is not None                    and (
+                        model in Models.CHATGPT_MODELS
+                        or model == "chatgpt" 
+                        or Models.is_gpt4_model(model)
+                    )
                     )
                     or (
                         model is None
@@ -420,7 +420,8 @@ class TextService:
                 )
             elif from_ask_command or from_ask_action:
                 response_model = response["model"]
-                if "gpt-3.5" in response_model or "gpt-4" in response_model:
+                # Use helper function to check for ChatGPT models (GPT-3.5 and GPT-4 variants)
+                if response_model in Models.CHATGPT_MODELS:
                     response_text = (
                         f"\n\n{response_text}"
                         if not response_text.startswith("\n\n")


### PR DESCRIPTION
- Add support for 5 new GPT model variants:
  * GPT-3.5 Turbo: gpt-3.5-turbo-0125 (16K tokens)
  * GPT-4 Turbo: gpt-4-turbo-2024-04-09 (128K tokens)
  * GPT-4o variants: gpt-4o-2024-05-13, gpt-4o-2024-08-06 (128K tokens each)
  * GPT-4o Mini: gpt-4o-mini, gpt-4o-mini-2024-07-18 (128K tokens each)

- Create robust helper functions in Models class:
  * is_gpt4_model() - Detects any GPT-4 variant including GPT-4o
  * is_high_context_model() - Identifies models with >8K token support
  * get_max_tokens() - Centralized token limit retrieval

- Replace hardcoded model checks across 7 files with centralized functions
- Update model collections with proper token mappings
- Fix type annotations and syntax errors

Resolves #475: '/index chat' command now works with gpt-4o and other new models